### PR TITLE
fix: 修复首次切换到设置tab时，侧边的默认菜单项没有高亮的问题

### DIFF
--- a/entrypoints/options/settings/index.tsx
+++ b/entrypoints/options/settings/index.tsx
@@ -167,10 +167,11 @@ export default function Settings() {
           >
             <div className="sidebar-inner-content">
               <Menu
+                selectedKeys={[currModule]}
                 mode="vertical"
                 items={blockModuleOptions}
                 onClick={onModuleChange}
-              ></Menu>
+              />
             </div>
             <div className="sidebar-inner-footer">
               {/* ******************* 保存 ******************* */}


### PR DESCRIPTION
- 修复：#225 