### PR TITLE
fix: prevent Send All Tabs from overwriting existing group

### DIFF
--- a/entrypoints/common/storage/tabListUtils.ts
+++ b/entrypoints/common/storage/tabListUtils.ts
@@ -961,7 +961,7 @@ export default class TabListUtils {
         }
       }
       const index = tag0.groupList.findIndex(g => !g.isStarred && !g.isLocked);
-      if (createNewGroup) {
+      if (createNewGroup || newTabs.length > 1) {
         tag0.groupList.splice(index > -1 ? index : tag0.groupList.length, 0, newtabGroup);
       } else {
         tag0.groupList.splice(index > -1 ? index : tag0.groupList.length, 1, newtabGroup);


### PR DESCRIPTION
## 修复 / Fix

修复当 `createNewGroupOnSendSingleTab` 设置为 No 时，Send All Tabs 会覆盖 Staging Area 中现有 group 的问题。

Fixes the issue where Send All Tabs overwrites the first unstarred/unlocked group in the Staging Area when `createNewGroupOnSendSingleTab` is set to No.

### 原因 / Root Cause

`createTabsIndependent` 函数中，最后的 splice 操作仅根据 `createNewGroupOnSendSingleTab` 设置来决定是插入还是替换，没有考虑 `newTabs.length > 1` 的情况。当发送多个 tabs 时，虽然创建了新的 group 对象，splice 仍然使用替换模式（deleteCount=1），导致现有 group 被覆盖。

In `createTabsIndependent`, the final splice only checks the `createNewGroupOnSendSingleTab` setting to decide insert vs replace, without considering `newTabs.length > 1`. When sending multiple tabs, a new group object is created but splice still uses replace mode (deleteCount=1), overwriting the existing group.

### 改动 / Changes

`entrypoints/common/storage/tabListUtils.ts` — 1 line change:

```diff
- if (createNewGroup) {
+ if (createNewGroup || newTabs.length > 1) {
```

Closes #333