### PR TITLE
feat: add confirmBeforeDeletingGroups setting

### DIFF
--- a/entrypoints/common/constants.ts
+++ b/entrypoints/common/constants.ts
@@ -166,6 +166,7 @@ export enum ENUM_SETTINGS_PROPS {
   /* 其他操作配置 */
   DELETE_UNLOCKED_EMPTY_GROUP = 'deleteUnlockedEmptyGroup', // 是否删除未锁定的空标签组
   CONFIRM_BEFORE_DELETING_TABS = 'confirmBeforeDeletingTabs', // 删除标签页前是否需要确认
+  CONFIRM_BEFORE_DELETING_GROUPS = 'confirmBeforeDeletingGroups', // 删除标签组前是否需要确认
   LINK_TEMPLATE = 'linkTemplate', // 链接模板
   TAB_COUNT_THRESHOLD = 'tabCountThreshold', // 分类中标签页超过该数量时，则右侧面板开启虚拟滚动
   GROUP_INSERT_POSITION = 'groupInsertPosition', // 标签组插入位置：在分类的标签组列表顶部还是底部

--- a/entrypoints/common/locale/modules/settings/enUS.ts
+++ b/entrypoints/common/locale/modules/settings/enUS.ts
@@ -78,6 +78,7 @@ const enUS: Record<LocaleKey, string> = {
   'settings.deleteUnlockedEmptyGroup.yes': 'Automatically remove (retain locked groups)',
   'settings.deleteUnlockedEmptyGroup.no': 'Do not',
   'settings.confirmBeforeDeletingTabs': 'Confirm before removing tabs?',
+  'settings.confirmBeforeDeletingGroups': 'Confirm before removing tab groups?',
   'settings.linkTemplate': 'Copy links format template for tab groups',
   'settings.linkTemplate.placeholder': 'Default format',
   'settings.linkTemplate.tooltip': 'Format for copy links, using the Mustache format',

--- a/entrypoints/common/locale/modules/settings/zhCN.ts
+++ b/entrypoints/common/locale/modules/settings/zhCN.ts
@@ -76,6 +76,7 @@ const zhCN = {
   'settings.deleteUnlockedEmptyGroup.yes': '自动删除（仍保留锁定的空标签组）',
   'settings.deleteUnlockedEmptyGroup.no': '不自动删除',
   'settings.confirmBeforeDeletingTabs': '删除标签页前是否需要确认：',
+  'settings.confirmBeforeDeletingGroups': '删除标签组前是否需要确认：',
   'settings.linkTemplate': '标签组-复制链接模板格式',
   'settings.linkTemplate.placeholder': '默认格式为',
   'settings.linkTemplate.tooltip': '复制链接所用的模板格式, 采用 Mustache 格式',

--- a/entrypoints/common/storage/settingsUtils.ts
+++ b/entrypoints/common/storage/settingsUtils.ts
@@ -55,6 +55,7 @@ const {
   /* 其他操作配置 */
   DELETE_UNLOCKED_EMPTY_GROUP,
   CONFIRM_BEFORE_DELETING_TABS,
+  CONFIRM_BEFORE_DELETING_GROUPS,
   LINK_TEMPLATE,
   TAB_COUNT_THRESHOLD,
   GROUP_INSERT_POSITION,
@@ -114,6 +115,7 @@ export default class SettingsUtils {
     /* 其他操作配置 */
     [DELETE_UNLOCKED_EMPTY_GROUP]: true, // 是否删除未锁定的空标签组
     [CONFIRM_BEFORE_DELETING_TABS]: false, // 删除标签页前是否需要确认
+    [CONFIRM_BEFORE_DELETING_GROUPS]: false, // 删除标签组前是否需要确认
     [LINK_TEMPLATE]: '{{url}} | {{title}}', // 复制的链接模板
     [TAB_COUNT_THRESHOLD]: 100, // 分类中标签页超过该数量时，则右侧面板开启虚拟滚动
     [GROUP_INSERT_POSITION]: 'top' as InsertPositions, // 标签组插入位置：在分类的标签组列表顶部还是底部

--- a/entrypoints/options/home/TabGroup.tsx
+++ b/entrypoints/options/home/TabGroup.tsx
@@ -69,6 +69,7 @@ import useMultiSelection from './hooks/multiSelection';
 const dndKey = dndKeys.tabItem;
 const {
   CONFIRM_BEFORE_DELETING_TABS,
+  CONFIRM_BEFORE_DELETING_GROUPS,
   DELETE_AFTER_RESTORE,
   GROUP_ACTION_BTNS_COMMONLY_USED,
 } = ENUM_SETTINGS_PROPS;
@@ -385,7 +386,14 @@ function TabGroup({
         disabled: tagLocked || isLocked,
         hoverColor: ENUM_COLORS.red,
         // validator: () => !isLocked,
-        onClick: () => setModalVisible(true),
+        onClick: () => {
+          const settings = settingsUtils.settings || {};
+          if (settings[CONFIRM_BEFORE_DELETING_GROUPS]) {
+            setModalVisible(true);
+          } else {
+            onRemove?.();
+          }
+        },
       },
       {
         key: 'restore',

--- a/entrypoints/options/home/TreeNodeActionModals.tsx
+++ b/entrypoints/options/home/TreeNodeActionModals.tsx
@@ -1,9 +1,13 @@
 import { useState, useCallback, useEffect, useMemo } from 'react';
 import { Modal } from 'antd';
 import { useIntlUtls } from '~/entrypoints/common/hooks/global';
+import { settingsUtils } from '~/entrypoints/common/storage';
+import { ENUM_SETTINGS_PROPS } from '~/entrypoints/common/constants';
 import MoveToModal from './MoveToModal';
 import useMoveTo from './hooks/moveTo';
 import type { RenderTreeNodeActionProps, MoveToCallbackProps } from './types';
+
+const { CONFIRM_BEFORE_DELETING_GROUPS } = ENUM_SETTINGS_PROPS;
 
 export interface ModalViewProps {
   open: boolean;
@@ -19,7 +23,12 @@ export function useTreeNodeAction(actionFn?: (props: RenderTreeNodeActionProps) 
     (props: RenderTreeNodeActionProps) => {
       setActionParams(props);
       if (props.actionName === 'remove') {
-        setRemoveModalVisible(true);
+        const settings = settingsUtils.settings || {};
+        if (props.node?.type === 'tabGroup' && !settings[CONFIRM_BEFORE_DELETING_GROUPS]) {
+          actionFn?.(props);
+        } else {
+          setRemoveModalVisible(true);
+        }
       } else if (props.actionName === 'moveTo') {
         setMoveToModalVisible(true);
       } else {

--- a/entrypoints/options/settings/FormModuleOtherActions.tsx
+++ b/entrypoints/options/settings/FormModuleOtherActions.tsx
@@ -9,6 +9,7 @@ import QuickActions from './components/QuickActions';
 const {
   DELETE_UNLOCKED_EMPTY_GROUP,
   CONFIRM_BEFORE_DELETING_TABS,
+  CONFIRM_BEFORE_DELETING_GROUPS,
   LINK_TEMPLATE,
   TAB_COUNT_THRESHOLD,
   GROUP_INSERT_POSITION,
@@ -59,6 +60,20 @@ export default function FormModuleOtherActions(
           values: { mark: '：' },
         })}
         name={CONFIRM_BEFORE_DELETING_TABS}
+      >
+        <Radio.Group>
+          <Radio value={true}>{$fmt('common.yes')}</Radio>
+          <Radio value={false}>{$fmt('common.no')}</Radio>
+        </Radio.Group>
+      </Form.Item>
+
+      {/* 删除标签组前是否需要确认 */}
+      <Form.Item<SettingsProps>
+        label={$fmt({
+          id: `settings.${CONFIRM_BEFORE_DELETING_GROUPS}`,
+          values: { mark: '：' },
+        })}
+        name={CONFIRM_BEFORE_DELETING_GROUPS}
       >
         <Radio.Group>
           <Radio value={true}>{$fmt('common.yes')}</Radio>

--- a/entrypoints/types/global.ts
+++ b/entrypoints/types/global.ts
@@ -185,6 +185,7 @@ export type SettingsProps = {
   /* 其他操作配置 */
   deleteUnlockedEmptyGroup?: boolean; // 是否删除未锁定的空标签组
   confirmBeforeDeletingTabs?: boolean; // 删除标签页前是否确认
+  confirmBeforeDeletingGroups?: boolean; // 删除标签组前是否确认
   linkTemplate?: string; // 链接模板
   tabCountThreshold?: number; // 分类中标签页超过该数量时，则右侧面板开启虚拟滚动
   groupInsertPosition?: InsertPositions; // 标签组插入位置：在分类的标签组列表顶部还是底部


### PR DESCRIPTION
## 功能 / Feature

新增独立配置项 `confirmBeforeDeletingGroups`，用于控制删除标签组时是否弹出确认框。

Add a new independent setting `confirmBeforeDeletingGroups` to control whether a confirmation modal appears when removing tab groups.

### 改动 / Changes

**8 files changed, 40 insertions(+), 2 deletions(-)**

1. `entrypoints/common/constants.ts` — 新增 enum 值 `CONFIRM_BEFORE_DELETING_GROUPS`
2. `entrypoints/types/global.ts` — 新增 `confirmBeforeDeletingGroups?: boolean` 类型定义
3. `entrypoints/common/storage/settingsUtils.ts` — 新增默认值 `false`
4. `entrypoints/common/locale/modules/settings/zhCN.ts` — 中文翻译
5. `entrypoints/common/locale/modules/settings/enUS.ts` — 英文翻译
6. `entrypoints/options/settings/FormModuleOtherActions.tsx` — 设置表单 UI
7. `entrypoints/options/home/TabGroup.tsx` — 标签组 ✕ 按钮根据设置决定是否弹窗
8. `entrypoints/options/home/TreeNodeActionModals.tsx` — 树状栏删除 tabGroup 节点根据设置决定是否弹窗

### 行为 / Behavior

- 默认值为 **No**（不确认，直接删除）
- 设为 **Yes** 时恢复原有行为（弹出 "Remove Reminder" 确认框）
- 删除 Tag（分类）始终弹出确认框，不受此设置影响
- 与现有导入/导出功能兼容，无需额外处理

Closes #332