### PR TITLE
fix: import useMemo in new tab search

### DIFF
--- a/entrypoints/nice-newtab/SearchEngine.tsx
+++ b/entrypoints/nice-newtab/SearchEngine.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect } from 'react';
+import { useState, useCallback, useEffect, useMemo } from 'react';
 import { Tooltip } from 'antd';
 import { settingsUtils } from '~/entrypoints/common/storage';
 import type { SearchEngine } from '~/entrypoints/types';


### PR DESCRIPTION
## 问题描述

新标签页搜索组件中使用了 `useMemo`，但未从 React 导入，打开新标签页时会导致运行错误。

## 修改内容

- 在 `SearchEngine.tsx` 中补充导入 `useMemo`

## 验证

- 已检查改动范围，仅包含一处导入修复
- 已通过 `git diff --check`
- 本地 TypeScript 类型检查未完成：当前环境依赖安装受锁文件与 package.json 不同步影响