### PR TITLE
fix: 修复右下角悬浮的全局快捷按钮组会被标签组遮挡的问题

### DIFF
--- a/entrypoints/options/App.tsx
+++ b/entrypoints/options/App.tsx
@@ -140,6 +140,7 @@ const StyledPageContainer = styled.div<{
   }
   .float-button-box {
     position: fixed;
+    z-index: 10;
     bottom: 24px;
     right: 30px;
     display: flex;


### PR DESCRIPTION
# 现象描述

版本 3.0.2 中，滚动页面时，发现右下角的全局快捷按钮会被时不时遮挡住：

<img width="2412" height="676" alt="image" src="https://github.com/user-attachments/assets/a3d285db-9d49-47f2-8fc5-50045a961ec8" />

# 排查
后来发现是被标签组标题容器给遮挡住了，查看了一下其 `z-index` 的值，果然比按钮组的值更高

# 修复

参考项目中已有的其他需要悬浮的组件，将右下角按钮组的 `z-index` 设置成了 `10`：

<img width="2417" height="210" alt="image" src="https://github.com/user-attachments/assets/e8558f74-d5bc-4646-844b-e72353f1d49c" />
