### PR TITLE
fix(theme): skip DOM manipulation in content script context

### DIFF
--- a/entrypoints/common/components/Root.tsx
+++ b/entrypoints/common/components/Root.tsx
@@ -41,7 +41,7 @@ export default function Root({
     changeLocale: changeLocaleCustom,
     messages,
   } = useCustomLocale();
-  const { themeTypeConfig, themeType, changeThemeType } = useThemeTypeConfig();
+  const { themeTypeConfig, themeType, changeThemeType } = useThemeTypeConfig(pageContext);
   const [hasReady, setHasReady] = useState(false);
   const [primaryColor, setPrimaryColor] = useState(PRIMARY_COLOR);
   const [pageWidthType, setPageWidthType] = useState<PageWidthTypes>('responsive');

--- a/entrypoints/common/hooks/global.ts
+++ b/entrypoints/common/hooks/global.ts
@@ -8,6 +8,7 @@ import type {
   LanguageTypes,
   ThemeTypeConfig,
   IntlForamtMessageParams,
+  PageContextType,
   ThemeTypes,
 } from '~/entrypoints/types';
 import { settingsUtils, themeUtils } from '~/entrypoints/common/storage';
@@ -106,7 +107,7 @@ function syncThemeTypeToLocalStorage(type: ThemeTypes) {
 }
 
 // theme type (light | dark | auto)
-export function useThemeTypeConfig() {
+export function useThemeTypeConfig(pageContext?: PageContextType) {
   const [themeType, setThemeType] = useState<ThemeTypes>(defaultThemeType);
   const [themeTypeConfig, setThemeTypeConfig] = useState<ThemeTypeConfig>(
     THEME_TYPE_CONFIG.light,
@@ -127,6 +128,8 @@ export function useThemeTypeConfig() {
 
     setThemeTypeConfig({ ...config });
     syncThemeTypeToLocalStorage(type);
+
+    if (pageContext === 'contentScriptPage') return;
 
     const el = document.documentElement;
     if (el) {


### PR DESCRIPTION
## 问题描述

#374 为文档根节点添加了样式注入，但由于内容脚本会注入到每个网页上，所以将背景色和 CSS 变量写到了所有网页的 `<html>` 上，导致常规的网页亦被“污染”：

<img width="610" height="129" alt="style" src="https://github.com/user-attachments/assets/91048457-dc1b-4613-84bb-f805c75db7db" />

## 修复方案

**核心思路**：document.documentElement 的样式只应作用于插件自己的页面，不应在内容脚本的页面上更改全局根节点。

**更改内容**：

1. `entrypoints/common/hooks/global.ts`：给 `useThemeTypeConfig` 增加 `pageContext` 参数，在 `updateThemeTypeConfig` 中仅当 `pageContext` 不是 `contentScriptPage` 时才写 `document.documentElement`。
2. `entrypoints/common/components/Root.tsx`：调用处传入已有的 `pageContext` prop: `useThemeTypeConfig(pageContext)`。
